### PR TITLE
Rails 3.1 assets pipeline

### DIFF
--- a/vendor/assets/stylesheets/bootstrap.min.css
+++ b/vendor/assets/stylesheets/bootstrap.min.css
@@ -171,7 +171,7 @@ input[disabled],select[disabled],textarea[disabled],input[readonly],select[reado
 .inputs-list label small{font-size:11px;font-weight:normal;}
 .inputs-list .inputs-list{margin-left:25px;margin-bottom:10px;padding-top:0;}
 .inputs-list:first-child{padding-top:6px;}
-.inputs-list li+li{padding-top:2px;}
+.inputs-list li + li{padding-top:2px;}
 .inputs-list input[type=radio],.inputs-list input[type=checkbox]{margin-bottom:0;}
 .form-stacked{padding-left:20px;}.form-stacked fieldset{padding-top:9px;}
 .form-stacked legend{padding-left:0;}
@@ -183,8 +183,8 @@ input[disabled],select[disabled],textarea[disabled],input[readonly],select[reado
 table{width:100%;margin-bottom:18px;padding:0;border-collapse:separate;*border-collapse:collapse;font-size:13px;border:1px solid #ddd;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}table th,table td{padding:10px 10px 9px;line-height:18px;text-align:left;}
 table th{padding-top:9px;font-weight:bold;vertical-align:middle;border-bottom:1px solid #ddd;}
 table td{vertical-align:top;}
-table th+th,table td+td{border-left:1px solid #ddd;}
-table tr+tr td{border-top:1px solid #ddd;}
+table th + th,table td + td{border-left:1px solid #ddd;}
+table tr + tr td{border-top:1px solid #ddd;}
 table tbody tr:first-child td:first-child{-webkit-border-radius:4px 0 0 0;-moz-border-radius:4px 0 0 0;border-radius:4px 0 0 0;}
 table tbody tr:first-child td:last-child{-webkit-border-radius:0 4px 0 0;-moz-border-radius:0 4px 0 0;border-radius:0 4px 0 0;}
 table tbody tr:last-child td:first-child{-webkit-border-radius:0 0 0 4px;-moz-border-radius:0 0 0 4px;border-radius:0 0 0 4px;}


### PR DESCRIPTION
plus (+) signs without spaces breaks the assets:precompile rake task.
