### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ to use the bootstrap javascript add the ones you want to application.js
 Thanks Twitter for Bootstrap
 http://twitter.github.com/bootstrap
 
-##License
+## License
 
 Copyright (c) 2011 Arun Agrawal
 
@@ -53,6 +53,6 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-##Credits
+## Credits
 
 Arun Agrawal: arunagw at gmail dot com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
